### PR TITLE
support node-red v1 async send api

### DIFF
--- a/network-stats.js
+++ b/network-stats.js
@@ -8,7 +8,8 @@ module.exports = function (RED) {
 
     const node = this
 
-    node.on('input', (msg) => {
+    node.on('input', (msg, send, done) => {
+      send = send || function() { node.send.apply(node,arguments) }
       si.networkInterfaceDefault()
         .then(iface => {
           si.networkStats(iface)
@@ -25,18 +26,26 @@ module.exports = function (RED) {
                     payload: ifaceData.tx_sec,
                     topic: 'transfered_bytes_sec'
                   })
-                  node.send([ payloadArr ])
+                  send([ payloadArr ])
 
                   break
                 }
               }
             })
             .catch(err => {
-              node.error('SI networkStats Error', err)
+              if (done) {
+                done(err)
+              } else {
+                node.error('SI networkStats Error', err)
+              }
             })
         })
         .catch(err => {
-          node.error('SI networkInterfaceDefault Error', err)
+          if (done) {
+            done(err)
+          } else {
+            node.error('SI networkInterfaceDefault Error', err)
+          }
         })
     })
   }


### PR DESCRIPTION
The syntax for listening to an incoming message and sending a message is changing in Node-RED v1.
The post about this from the official Node-RED blog explains why it's changing, what's the new syntax, and how to maintain backward compatibility:
https://nodered.org/blog/2019/09/20/node-done

This PR changes the syntax based on the example from the blog post.

Thanks.